### PR TITLE
South introspection rule for custom PriceField

### DIFF
--- a/django_prices/models.py
+++ b/django_prices/models.py
@@ -3,19 +3,13 @@ from prices import Price
 
 from . import forms
 
-try:
-    from south.modelsinspector import add_introspection_rules
-    add_introspection_rules([], ["^django_prices\.models\.PriceField"])
-except ImportError:
-    pass
-
 
 class PriceField(models.DecimalField):
 
     __metaclass__ = models.SubfieldBase
     description = "A field which stores a price."
 
-    def __init__(self, verbose_name, currency, **kwargs):
+    def __init__(self, verbose_name=None, currency=None, **kwargs):
         self.currency = currency
         super(PriceField, self).__init__(verbose_name, **kwargs)
 
@@ -42,3 +36,15 @@ class PriceField(models.DecimalField):
                     'form_class': forms.PriceField}
         defaults.update(kwargs)
         return super(PriceField, self).formfield(**defaults)
+
+try:
+    from south.modelsinspector import add_introspection_rules
+except ImportError:
+    pass
+else:
+    rules = [
+        ((PriceField,), [], {
+            'currency': ('currency', {})
+        }),
+    ]
+    add_introspection_rules(rules, ["^django_prices\.models"])


### PR DESCRIPTION
Users of South(http://south.aeracode.org/) will need to have the custom `PriceField` model field added to South's introspection rules[1].

[1] http://south.readthedocs.org/en/latest/customfields.html
