### PR TITLE
Add custom JSON serialization

### DIFF
--- a/django_prices/models.py
+++ b/django_prices/models.py
@@ -31,6 +31,12 @@ class PriceField(models.DecimalField):
             value = value.net
         return super(PriceField, self).get_prep_value(value)
 
+    def value_to_string(self, obj):
+        value = self._get_val_from_obj(obj)
+        if value:
+            return value.net
+        return super(PriceField, self).value_to_string(value)
+
     def formfield(self, **kwargs):
         defaults = {'currency': self.currency,
                     'form_class': forms.PriceField}


### PR DESCRIPTION
Because the custom serialization was missing, dumpdata generated JSON
like "price": "Price('200', currency='USD')", which can't be loaded.
New serialization method saves just the net value, like the
complementary db function.
