### PR TITLE
Update prices_i18n.py

### DIFF
--- a/django_prices/templatetags/prices_i18n.py
+++ b/django_prices/templatetags/prices_i18n.py
@@ -1,19 +1,21 @@
 from babel.numbers import format_currency
 from django import template
+from django.utils import translation
 
 register = template.Library()
-
+language = translation.get_language()
+locale = translation.to_locale(language)
 
 @register.simple_tag
 def gross(price):
-    return format_currency(price.gross, price.currency)
+    return format_currency(price.gross, price.currency, locale=locale)
 
 
 @register.simple_tag
 def net(price):
-    return format_currency(price.net, price.currency)
+    return format_currency(price.gross, price.currency, locale=locale)
 
 
 @register.simple_tag
 def tax(price):
-    return format_currency(price.tax, price.currency)
+    return format_currency(price.gross, price.currency, locale=locale)

--- a/django_prices/templatetags/prices_i18n.py
+++ b/django_prices/templatetags/prices_i18n.py
@@ -13,9 +13,9 @@ def gross(price):
 
 @register.simple_tag
 def net(price):
-    return format_currency(price.gross, price.currency, locale=locale)
+    return format_currency(price.net, price.currency, locale=locale)
 
 
 @register.simple_tag
 def tax(price):
-    return format_currency(price.gross, price.currency, locale=locale)
+    return format_currency(price.tax, price.currency, locale=locale)


### PR DESCRIPTION
By default, babel will look at an environment variable to determine locale for currency.  Since this doesn't look at the user's computer, we need to call this function with the locale variable set.