### PR TITLE
Add test for field validations

### DIFF
--- a/django_prices/tests.py
+++ b/django_prices/tests.py
@@ -48,6 +48,12 @@ class PriceFieldTest(TestCase):
         self.assertEqual(form_field.currency, 'BTC')
         self.assertTrue(isinstance(form_field.widget, widgets.PriceInput))
 
+    def test_field_passes_all_validations(self):
+        field = PriceField(name='price', currency='BTC', default='5',
+                           max_digits=9, decimal_places=2)
+        errors = field.check()
+        self.assertFalse(errors)
+
 
 class PriceInputTest(TestCase):
 

--- a/django_prices/tests.py
+++ b/django_prices/tests.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 from unittest import TestCase
+from unittest.mock import MagicMock
 
 import django
 from prices import Price
@@ -51,6 +52,7 @@ class PriceFieldTest(TestCase):
     def test_field_passes_all_validations(self):
         field = PriceField(name='price', currency='BTC', default='5',
                            max_digits=9, decimal_places=2)
+        field.model = MagicMock()
         errors = field.check()
         self.assertFalse(errors)
 


### PR DESCRIPTION
Django `>1.9` by default checks all fields. This PR adds test for these validations.

This PR requires https://github.com/mirumee/prices/pull/16 to pass all tests.