### PR TITLE
Render price without decimal digits if they are equal to 0

### DIFF
--- a/django_prices/templatetags/prices.py
+++ b/django_prices/templatetags/prices.py
@@ -5,19 +5,28 @@ from django import template
 register = template.Library()
 
 
-@register.inclusion_tag('prices/price.html')
-def gross(price):
-    return {'amount': price.gross, 'currency': price.currency}
+def normalize_price(price, normalize):
+    if normalize:
+        return price.normalize()
+    return price
 
 
 @register.inclusion_tag('prices/price.html')
-def net(price):
-    return {'amount': price.net, 'currency': price.currency}
+def gross(price, normalize=False):
+    return {'amount': normalize_price(price, normalize),
+            'currency': price.currency}
 
 
 @register.inclusion_tag('prices/price.html')
-def tax(price):
-    return {'amount': price.tax, 'currency': price.currency}
+def net(price, normalize=False):
+    return {'amount': normalize_price(price, normalize),
+            'currency': price.currency}
+
+
+@register.inclusion_tag('prices/price.html')
+def tax(price, normalize=False):
+    return {'amount': normalize_price(price, normalize),
+            'currency': price.currency}
 
 
 @register.filter

--- a/django_prices/templatetags/prices_i18n.py
+++ b/django_prices/templatetags/prices_i18n.py
@@ -23,6 +23,12 @@ def get_currency_fraction(currency):
     return fraction[0]
 
 
+def change_pattern(pattern, currency, normalize):
+    fractions = get_currency_fraction(currency)
+    replacement = '#' if normalize else '0'
+    return pattern.replace('.00', '.' + replacement * fractions)
+
+
 def format_price(value, currency, html=False, normalize=False):
     """
     Format decimal value as currency
@@ -46,12 +52,7 @@ def format_price(value, currency, html=False, normalize=False):
         locale = Locale.parse(locale_code)
     currency_format = locale.currency_formats.get('standard')
     pattern = currency_format.pattern
-    if normalize:
-        pattern = pattern.replace('.00', '.##')
-        currency_fractions = get_currency_fraction(currency)
-        # Format don't handle values with three decimal digits
-        if currency_fractions == 3:
-            normalize = False
+    pattern = change_pattern(pattern, currency, normalize)
 
     if html:
         pattern = re.sub(

--- a/django_prices/templatetags/prices_i18n.py
+++ b/django_prices/templatetags/prices_i18n.py
@@ -14,7 +14,7 @@ from django.utils.translation import get_language, to_locale
 register = template.Library()
 
 
-def format_price(value, currency):
+def format_price(value, currency, html=False, normalize=False):
     """
     Format decimal value as currency
     """
@@ -37,28 +37,33 @@ def format_price(value, currency):
         locale = Locale.parse(locale_code)
     currency_format = locale.currency_formats.get('standard')
     pattern = currency_format.pattern
-    pattern = re.sub(
-        '(\xa4+)', '<span class="currency">\\1</span>', pattern)
-    result = format_currency(value, currency, pattern, locale=locale_code)
+    if normalize:
+        pattern = pattern.replace('.00', '.##')
+
+    if html:
+        pattern = re.sub(
+            '(\xa4+)', '<span class="currency">\\1</span>', pattern)
+    result = format_currency(
+        value, currency, pattern, locale=locale_code, currency_digits=False)
     return mark_safe(result)
 
 
 @register.simple_tag
-def gross(price, html=False):
-    if html:
-        return format_price(price.gross, price.currency)
+def gross(price, html=False, normalize=False):
+    if html or normalize:
+        return format_price(price.gross, price.currency, html, normalize)
     return currencyfmt(price.gross, price.currency)
 
 
 @register.simple_tag
-def net(price, html=False):
-    if html:
-        return format_price(price.net, price.currency)
+def net(price, html=False, normalize=False):
+    if html or normalize:
+        return format_price(price.net, price.currency, html, normalize)
     return currencyfmt(price.net, price.currency)
 
 
 @register.simple_tag
-def tax(price, html=False):
-    if html:
-        return format_price(price.tax, price.currency)
+def tax(price, html=False, normalize=False):
+    if html or normalize:
+        return format_price(price.tax, price.currency, html, normalize)
     return currencyfmt(price.tax, price.currency)

--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -243,7 +243,7 @@ def test_normalize_price(value, normalize, expected):
                           (Decimal('12.20'), '12.2'),
                           (Decimal('1222'), '1,222'),
                           (Decimal('12.23'), '12.23')])
-def test_normalize_price(value, expected):
+def test_format_normalize_price(value, expected):
     formatted_price = prices_i18n.format_price(value, 'USD', normalize=True)
     assert formatted_price == '$%s' % expected
 

--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -131,6 +131,16 @@ def test_templatetag_gross_html(price_fixture):
     assert gross == '<span class="currency">$</span>15.00'
 
 
+def test_templatetag_gross_normalize(price_fixture):
+    gross = prices_i18n.gross(price_fixture, normalize=True)
+    assert gross == '$15'
+
+
+def test_templatetag_gross_html_normalize(price_fixture):
+    gross = prices_i18n.gross(price_fixture, html=True, normalize=True)
+    assert gross == '<span class="currency">$</span>15'
+
+
 def test_templatetag_net(price_fixture):
     net = prices_i18n.net(price_fixture)
     assert net == '$10.00'
@@ -141,6 +151,22 @@ def test_templatetag_net_html(price_fixture):
     assert net == '<span class="currency">$</span>10.00'
 
 
+def test_templatetag_net_html_normalize(price_fixture):
+    net = prices_i18n.net(price_fixture, html=True, normalize=True)
+    assert net == '<span class="currency">$</span>10'
+
+
+def test_templatetag_net_normalize(price_fixture):
+    net = prices_i18n.net(price_fixture, normalize=True)
+    assert net == '$10'
+
+
+def test_templatetag_net_normalize_with_decimals():
+    price = Price(net='12.23', currency='USD')
+    net = prices_i18n.net(price, normalize=True)
+    assert net == '$12.23'
+
+
 def test_templatetag_tax(price_fixture):
     tax = prices_i18n.tax(price_fixture)
     assert tax == '$5.00'
@@ -149,6 +175,16 @@ def test_templatetag_tax(price_fixture):
 def test_templatetag_tax_html(price_fixture):
     tax = prices_i18n.tax(price_fixture, html=True)
     assert tax == '<span class="currency">$</span>5.00'
+
+
+def test_templatetag_tax_normalize(price_fixture):
+    tax = prices_i18n.tax(price_fixture, normalize=True)
+    assert tax == '$5'
+
+
+def test_templatetag_tax_html_normalize(price_fixture):
+    tax = prices_i18n.tax(price_fixture, html=True, normalize=True)
+    assert tax == '<span class="currency">$</span>5'
 
 
 def test_templatetag_discount_amount_for():
@@ -192,3 +228,34 @@ def test_non_cannonical_locale_zh_CN(price_fixture, settings):
     translation.activate('zh_CN')
     tax = prices_i18n.tax(price_fixture, html=True)
     assert tax == '<span class="currency">US$</span>5.00'  # 'US' before '$'
+
+
+@pytest.mark.parametrize('value, normalize, expected',
+                         [(Decimal('12.00'), True, Decimal('12')),
+                          (Decimal('12.00'), False, Decimal('12.00')),
+                          (Decimal('12.23'), True, Decimal('12.23'))])
+def test_normalize_price(value, normalize, expected):
+    assert tags.normalize_price(value, normalize) == expected
+
+
+@pytest.mark.parametrize('value, expected',
+                         [(Decimal('12'), '12'),
+                          (Decimal('12.20'), '12.2'),
+                          (Decimal('1222'), '1,222'),
+                          (Decimal('12.23'), '12.23')])
+def test_normalize_price(value, expected):
+    formatted_price = prices_i18n.format_price(value, 'USD', normalize=True)
+    assert formatted_price == '$%s' % expected
+
+
+@pytest.mark.parametrize('value', [Decimal('12.22'), Decimal('1222.22')])
+def test_normalize_same_as_formatted(value):
+    formatted_price = prices_i18n.format_price(value, 'USD', normalize=True)
+    assert formatted_price == prices_i18n.net(Price(net=value, currency='USD'))
+
+
+@pytest.mark.parametrize('value', [Decimal('12'), Decimal('1222')])
+def test_normalize_same_as_formatted(value):
+    formatted_price = prices_i18n.format_price(value, 'USD', normalize=True)
+    net = prices_i18n.net(Price(net=value, currency='USD'))
+    assert not formatted_price == net

--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -254,10 +254,11 @@ def test_format_normalize_price_no_digits():
     assert formatted_price == '¥123'
 
 
-def test_format_normalize_price_three_digits():
-    value = 123.002
+@pytest.mark.parametrize(
+    'value,expected', [(123.002, 'BHD123.002'), (123.000, 'BHD123')])
+def test_format_normalize_price_three_digits(value, expected):
     normalized_price = prices_i18n.format_price(value, 'BHD', normalize=True)
-    assert normalized_price == 'BHD123.002'
+    assert normalized_price == expected
 
 
 @pytest.mark.parametrize('value', [Decimal('12.22'), Decimal('1222.22')])

--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from __future__ import unicode_literals
 
 from decimal import Decimal
@@ -246,6 +247,17 @@ def test_normalize_price(value, normalize, expected):
 def test_format_normalize_price(value, expected):
     formatted_price = prices_i18n.format_price(value, 'USD', normalize=True)
     assert formatted_price == '$%s' % expected
+
+
+def test_format_normalize_price_no_digits():
+    formatted_price = prices_i18n.format_price(123, 'JPY', normalize=True)
+    assert formatted_price == '¥123'
+
+
+def test_format_normalize_price_three_digits():
+    value = 123.002
+    normalized_price = prices_i18n.format_price(value, 'BHD', normalize=True)
+    assert normalized_price == 'BHD123.002'
 
 
 @pytest.mark.parametrize('value', [Decimal('12.22'), Decimal('1222.22')])


### PR DESCRIPTION
Allow templatetags to render price without decimal digits (if they are equal to 0). This change was suggested in issue #32

Example usage: `{% gross price normalize=True %}`
