### PR TITLE
Upgrade BabelDjango to django-babel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,39 @@
 language: python
 sudo: false
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+cache:
+  pip: true
 install:
-  - pip install tox codecov
+  - pip install tox-travis codecov
 script:
   - tox
 env:
-  - TOXENV=py27-django18
-  - TOXENV=py27-django110
-  - TOXENV=py34-django18
-  - TOXENV=py34-django110
-  - TOXENV=py34-django111
-  - TOXENV=py34-django_master
-  - TOXENV=py35-django18
-  - TOXENV=py35-django110
-  - TOXENV=py35-django111
-  - TOXENV=py35-django_master
+  matrix:
+    - DJANGO="1.11"
+    - DJANGO="2.0"
+    - DJANGO="master"
 matrix:
   allow_failures:
-    - env: TOXENV=py34-django111
-    - env: TOXENV=py34-django_master
-    - env: TOXENV=py35-django111
-    - env: TOXENV=py35-django_master
+    - python: "3.4"
+      env: DJANGO="2.0"
+    - python: "3.4"
+      env: DJANGO="master"
+    - python: "3.5"
+      env: DJANGO="2.0"
+    - python: "3.5"
+      env: DJANGO="master"
+    - python: "3.6"
+      env: DJANGO="2.0"
+    - python: "3.6"
+      env: DJANGO="master"
+  exclude:
+    - python: "2.7"
+      env: DJANGO="2.0"
+    - python: "2.7"
+      env: DJANGO="master"
 after_success:
   - codecov
-addons:
-  apt:
-    sources:
-      - deadsnakes
-    packages:
-      - python3.5

--- a/django_prices/models.py
+++ b/django_prices/models.py
@@ -65,10 +65,7 @@ class PriceField(models.DecimalField):
 
     def get_db_prep_save(self, value, connection):
         value = self.get_prep_value(value)
-        if django.VERSION < (1, 9):
-            db_value = connection.ops.value_to_db_decimal
-        else:
-            db_value = connection.ops.adapt_decimalfield_value
+        db_value = connection.ops.adapt_decimalfield_value
         return db_value(value, self.max_digits, self.decimal_places)
 
     def value_to_string(self, obj):

--- a/django_prices/templatetags/prices_i18n.py
+++ b/django_prices/templatetags/prices_i18n.py
@@ -1,15 +1,16 @@
 from __future__ import unicode_literals
 
-from decimal import Decimal, InvalidOperation
 import re
+from decimal import Decimal, InvalidOperation
 
 from babel.core import Locale, UnknownLocaleError, get_global
 from babel.numbers import format_currency
-from babeldjango.templatetags.babel import currencyfmt
 from django import template
 from django.conf import settings
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language, to_locale
+
+from django_babel.templatetags.babel import currencyfmt
 
 register = template.Library()
 

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,12 @@ setup(
     author_email='hello@mirumee.com',
     description='Django fields for the prices module',
     license='BSD',
-    version='0.6.2',
+    version='0.7.0',
     url='https://github.com/mirumee/django-prices',
     packages=['django_prices', 'django_prices.templatetags'],
     include_package_data=True,
     classifiers=CLASSIFIERS,
     install_requires=[
-        'Babel>=2.2', 'BabelDjango', 'django', 'prices>=0.5.7,<0.6a0'],
+        'Babel>=2.2', 'Django>=1.11', 'django-babel', 'prices>=0.5.7,<0.6a0'],
     platforms=['any'],
     zip_safe=False)

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,36 @@
 [tox]
 envlist =
-    py{27,34,35}-django{18,110,111}
-    py{34,35}-django_master
+    py{27,34,35,36}-django111
+    py{34,35,36}-django{20,_master}
 
 [testenv]
 pip_pre = true
 deps =
-    django18: django>=1.8,<1.9
-    django110: django>=1.10,<1.11
-    django111: django>=1.11a1,<1.12
-    django_master: https://github.com/django/django/archive/master.tar.gz
     pytest
     pytest-cov
     pytest-django
-commands = pytest --cov --cov-report=
+commands =
+    django111: pip install "django>=1.11a1,<1.12" --upgrade --pre
+    django20: pip install "django>=2.0a1,<2.1" --upgrade --pre
+    django_master: pip install https://github.com/django/django/archive/master.tar.gz
+    python manage.py collectstatic --noinput
+    pytest --cov --cov-report=
 setenv =
     PYTHONPATH=.
+
+[travis]
+python =
+    2.7: py27
+    3.4: py34
+    3.5: py35
+    3.6: py36
+unignore_outcomes = True
+
+[travis:env]
+DJANGO =
+    1.11: django111
+    2.0: django20
+    master: django_master
 
 [pytest]
 testpaths = tests


### PR DESCRIPTION
Also require Django 1.11 or later so we can prepare for Django 2.0.