### PR TITLE
Django 2.0 compat fix

### DIFF
--- a/django_prices/widgets.py
+++ b/django_prices/widgets.py
@@ -20,9 +20,6 @@ class PriceInput(forms.TextInput):
             value = value.net
         return value
 
-    def _format_value(self, value):
-        return self.format_value(value)
-
     def render(self, name, value, attrs=None):
         widget = super(PriceInput, self).render(name, value, attrs=attrs)
         return render_to_string(self.template, {'widget': widget,

--- a/django_prices/widgets.py
+++ b/django_prices/widgets.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 from django import forms
 from django.template.loader import render_to_string
-
 from prices import Price
 
 __all__ = ['PriceInput']
@@ -16,10 +15,13 @@ class PriceInput(forms.TextInput):
         self.currency = currency
         super(PriceInput, self).__init__(*args, **kwargs)
 
-    def _format_value(self, value):
+    def format_value(self, value):
         if isinstance(value, Price):
             value = value.net
         return value
+
+    def _format_value(self, value):
+        return self.format_value(value)
 
     def render(self, name, value, attrs=None):
         widget = super(PriceInput, self).render(name, value, attrs=attrs)

--- a/tox.ini
+++ b/tox.ini
@@ -7,12 +7,12 @@ envlist =
 [testenv]
 pip_pre = true
 deps =
+    django111: django>=1.11a1,<1.12
+    django20: django>=2.0,<2.1
     pytest
     pytest-cov
     pytest-django
 commands =
-    django111: pip install "django>=1.11a1,<1.12" --upgrade --pre
-    django20: pip install "django>=2.0a1,<2.1" --upgrade --pre
     django_master: pip install https://github.com/django/django/archive/master.tar.gz
     pytest --cov --cov-report=
 setenv =


### PR DESCRIPTION
`_format_value` is now `format_value`. It actually is deprecated since 1.10. I still keep the `_format_value` for backward compatible, since I'm not sure about your policy regarding support older Django version. Please let me know if it is ok to remove I will update the PR.