### PR TITLE
Add required auto_created flag to TaxedMoneyField, fix code style and bump ver. to Beta 5

### DIFF
--- a/django_prices/models.py
+++ b/django_prices/models.py
@@ -49,8 +49,7 @@ class MoneyField(models.DecimalField):
         return super(MoneyField, self).value_to_string(value)
 
     def formfield(self, **kwargs):
-        defaults = {'currency': self.currency,
-                    'form_class': forms.MoneyField}
+        defaults = {'currency': self.currency, 'form_class': forms.MoneyField}
         defaults.update(kwargs)
         return super(MoneyField, self).formfield(**defaults)
 
@@ -63,7 +62,7 @@ class MoneyField(models.DecimalField):
         validators = list(
             itertools.chain(self.default_validators, self._validators))
         return validators + [MoneyPrecisionValidator(
-                self.currency, self.max_digits, self.decimal_places)]
+            self.currency, self.max_digits, self.decimal_places)]
 
     def deconstruct(self):
         name, path, args, kwargs = super(MoneyField, self).deconstruct()
@@ -78,6 +77,7 @@ class TaxedMoneyField(object):
     empty_values = list(validators.EMPTY_VALUES)
 
     # Field flags
+    auto_created = False
     blank = True
     concrete = False
     editable = False
@@ -92,7 +92,6 @@ class TaxedMoneyField(object):
         self.gross_field = gross_field
 
         self.column = None
-        self.attname = None
 
     def __str__(self):
         return (

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author_email='hello@mirumee.com',
     description='Django fields for the prices module',
     license='BSD',
-    version='1.0.0-beta4',
+    version='1.0.0-beta5',
     url='https://github.com/mirumee/django-prices',
     packages=['django_prices', 'django_prices.templatetags'],
     include_package_data=True,


### PR DESCRIPTION
Before releasing Beta 4 I've cut the `auto_created` flag from `TaxedMoneyField` based on what I've looked up on Django source and our test suite. This passed the test, but apparently the flag was required by Django's query building facilities for resolving possible reverse relations.

Code from this PR was tested with local Saleor fork that I'm using to develop price handling update. All tests are now passing with model using this field successfully saving to DB and then deleting from it. I've also tested `makemigrations` for it and found out that its ignored and its creation on model doesn't cause new migration to appear, which imho is what we want.