### PR TITLE
Add missing primary_key flag to TaxedModelField

### DIFF
--- a/django_prices/models.py
+++ b/django_prices/models.py
@@ -92,6 +92,7 @@ class TaxedMoneyField(object):
         self.gross_field = gross_field
 
         self.column = None
+        self.primary_key = False
 
     def __str__(self):
         return (

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author_email='hello@mirumee.com',
     description='Django fields for the prices module',
     license='BSD',
-    version='1.0.0-beta5',
+    version='1.0.0-beta6',
     url='https://github.com/mirumee/django-prices',
     packages=['django_prices', 'django_prices.templatetags'],
     include_package_data=True,


### PR DESCRIPTION
This PR adds `primary_key = False` to our `TaxedMoneyField` which is accessed by Django's ORM when `save()` is called with `update_fields`.

Also bumps version to Beta 6