### PR TITLE
Improve default= handling on MoneyField

### DIFF
--- a/django_prices/models.py
+++ b/django_prices/models.py
@@ -15,6 +15,11 @@ class MoneyField(models.DecimalField):
 
     def __init__(self, verbose_name=None, currency=None, **kwargs):
         self.currency = currency
+        if (isinstance(kwargs.get('default'), Money) and
+                kwargs['default'].currency != self.currency):
+            raise ValueError(
+                'Invalid currency for default value: %r (expected %r)' % (
+                    kwargs['default'].currency, self.currency))
         super(MoneyField, self).__init__(verbose_name, **kwargs)
 
     def from_db_value(self, value, expression, connection, context):
@@ -67,6 +72,8 @@ class MoneyField(models.DecimalField):
     def deconstruct(self):
         name, path, args, kwargs = super(MoneyField, self).deconstruct()
         kwargs['currency'] = self.currency
+        if isinstance(kwargs.get('default'), Money):
+            kwargs['default'] = str(kwargs['default'].amount)
         return name, path, args, kwargs
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django_prices.models import MoneyField, TaxedMoneyField
+from prices import Money
 
 
 class Model(models.Model):
@@ -10,3 +11,9 @@ class Model(models.Model):
         'gross', currency='BTC', default='5', max_digits=9,
         decimal_places=2)
     price = TaxedMoneyField(net_field='price_net', gross_field='price_gross')
+
+
+class ModelWithDefault(models.Model):
+    price = MoneyField(
+        currency='USD', default=Money('0', 'USD'), max_digits=9,
+        decimal_places=2)


### PR DESCRIPTION
This PR improves our handling for scenario when `MoneyField.default` is of type `Money`:

`MoneyField.__init__` validates that `Money.currency` is same as one passed in the `currency` argument, and raises `ValueError` otherwise, so its impossible to create model with field as such:

```python
class InvalidModel(models.Model):
    price = MoneyField(
        currency='USD', default=Money('0', 'EUR'), max_digits=9,
        decimal_places=2)
```

`MoneyField.deconstruct` tests if default value is instance of `Money`, and if that is the case, deconstructs `kwargs['default']` to `str(Money.amount)`, so migrations generated by Django don't import `prices` and don't construct explicit `Money`, which should make them more future-proof.

If somebody out there already has model like in our `InvalidModel` change, this will be breaking change for his/her project.