### PR TITLE
Make TaxedMoneyField hashable

### DIFF
--- a/django_prices/models.py
+++ b/django_prices/models.py
@@ -109,6 +109,9 @@ class TaxedMoneyField(object):
         gross_val = getattr(instance, self.gross_field)
         return TaxedMoney(net_val, gross_val)
 
+    def __hash__(self):
+        return hash(self.creation_counter)
+
     def __set__(self, instance, value):
         net = None
         gross = None

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author_email='hello@mirumee.com',
     description='Django fields for the prices module',
     license='BSD',
-    version='1.0.1',
+    version='1.0.2',
     url='https://github.com/mirumee/django-prices',
     packages=['django_prices', 'django_prices.templatetags'],
     include_package_data=True,


### PR DESCRIPTION
After upgrading graphene and graphene-django to latest versions in Saleor, converting `TaxedMoneyField` fields stopped working and results in the error:
```
TypeError: unhashable type: 'TaxedMoneyField'
```

Related issue in Saleor: https://github.com/mirumee/saleor/issues/2454

Django model fields are by default hashable. Since we also have a creation counter in TaxedMoneyField, I used the default `__hash__` implementation as in other Django fields.