### PR TITLE
Django 2.1 support: add render argument to MoneyInput render method 

### DIFF
--- a/django_prices/widgets.py
+++ b/django_prices/widgets.py
@@ -18,7 +18,7 @@ class MoneyInput(forms.TextInput):
             return value.amount
         return value
 
-    def render(self, name, value, attrs=None):
-        widget = super(MoneyInput, self).render(name, value, attrs=attrs)
+    def render(self, name, value, attrs=None, renderer=None):
+        widget = super(MoneyInput, self).render(name, value, attrs=attrs, renderer=renderer)
         return render_to_string(self.template, {
             'widget': widget, 'value': value, 'currency': self.currency})


### PR DESCRIPTION
The renderer argument was added in Django 1.11. 
Support for subclasses that don’t accept it is removed in Django 2.1 and you get a TypeError:
```
TypeError: render() got an unexpected keyword argument 'renderer'
```