### PR TITLE
Feature: multi-currency support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,28 @@ class DonateForm(forms.Form):
                     MaxMoneyValidator(Money(500, 'EUR'))])
 ```
 
+And for multi-currency:
+
+```python
+from django.db import models
+
+from django_prices.models import MoneyCurrencyField, MoneyField, TaxedMoneyField
+
+
+class Product(models.Model):
+    name = models.CharField('Name')
+    currency = models.CharField(max_length=3, default="BTC")
+    price_net_amount = models.DecimalField(max_digits=9, decimal_places=2)
+    price_net = MoneyCurrencyField(
+        amount_field="price_net_amount", currency_field="currency"
+    )
+    price_gross_amount = models.DecimalField(max_digits=9, decimal_places=2)
+    price_gross = MoneyCurrencyField(
+        amount_field="price_gross_amount", currency_field="currency"
+    )
+    price = TaxedMoneyField(net_field="price_net", gross_field="price_gross")
+```
+
 And templates:
 
 ```html+django

--- a/README.md
+++ b/README.md
@@ -104,17 +104,17 @@ It will be rendered as a following structure (for example with English locale):
 
 ## How to migrate to django-prices 2.0
 
-Version 2.0 provides major changes in the models. It allows to store prices in many currencies in one table.
+Version 2.0 introduces major changes to how prices data is stored in models, enabling setting price's currency per model instance.
 
 Steps to migrate:
 
-1. Replace all occurrences of `MoneyField` by `DecimalField` in your **models** and remove `currency` argument from them, e.g. change
+1. Replace all occurrences of the `MoneyField` with `DecimalField` in your **models** and remove the `currency` argument from them:
 ```python
     price_net = MoneyField(
         "net", currency="BTC", default="5", max_digits=9, decimal_places=2
     )
 ```
-to the
+Updated code:
 ```python
     price_net = models.DecimalField("net", default="5", max_digits=9, decimal_places=2)
 ```
@@ -143,7 +143,7 @@ to the
 
 7. Run `python manage.py makemigrations` and `python manage.py migrate`.
 
-8. If you use forms, remove `currency` argument and add list of choices `available_currencies`. Moreover, remove `MoneyField` from `ModelForm`'s fields list; you should declare it explicitly:
+8. In your forms, remove the `currency` argument and add `available_currencies` with available choices. If the form specified `MoneyFields` in `fields` option, replace those with explicit declarations instead:
 ```python
 AVAILABLE_CURRENCIES = [("BTC", "bitcoins"), ("USD", "US dollar")]
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ class DonateForm(forms.Form):
         decimal_places=2,
         validators=[
             MoneyPrecisionValidator(),
-            MinMoneyValidator(Money(5, "EUR")),
-            MaxMoneyValidator(Money(500, "EUR")),
+            MinMoneyValidator(Money(5, "USD")),
+            MaxMoneyValidator(Money(500, "USD")),
         ],
     )
 ```

--- a/README.md
+++ b/README.md
@@ -30,9 +30,12 @@ from django import forms
 
 from django_prices.forms import MoneyField
 
+AVAILABLE_CURRENCIES = [("BTC", "bitcoins"), ("USD", "US dollar")]
+
+
 class ProductForm(forms.Form):
-    name = forms.CharField(label='Name')
-    price_net = MoneyField(label='net', default_currency='BTC')
+    name = forms.CharField(label="Name")
+    price_net = MoneyField(label="net", available_currencies=AVAILABLE_CURRENCIES)
 ```
 
 And validators:
@@ -45,13 +48,20 @@ from django_prices.forms import MoneyField
 from django_prices.validators import (
     MaxMoneyValidator, MinMoneyValidator, MoneyPrecisionValidator)
 
+
 class DonateForm(forms.Form):
-    donator_name = forms.CharField(label='Your name')
+    donator_name = forms.CharField(label="Your name")
     donation = MoneyField(
-        label='net', default_currency='EUR', max_digits=9, decimal_places=2,
-        validators=[MoneyPrecisionValidator(),
-                    MinMoneyValidator(Money(5, 'EUR')),
-                    MaxMoneyValidator(Money(500, 'EUR'))])
+        label="net",
+        available_currencies=[("BTC", "bitcoins"), ("USD", "US dollar")],
+        max_digits=9,
+        decimal_places=2,
+        validators=[
+            MoneyPrecisionValidator(),
+            MinMoneyValidator(Money(5, "EUR")),
+            MaxMoneyValidator(Money(500, "EUR")),
+        ],
+    )
 ```
 
 It also provides support for templates:
@@ -133,12 +143,14 @@ to the
 
 7. Run `python manage.py makemigrations` and `python manage.py migrate`.
 
-8. If you use forms, change `currency` to `default_currency`, add (if you need) list `available_currencies` and remove `MoneyField` from `ModelForm`'s fields list; you should declare it explicitly:
+8. If you use forms, remove `currency` argument and add list of choices `available_currencies`. Moreover, remove `MoneyField` from `ModelForm`'s fields list; you should declare it explicitly:
 ```python
+AVAILABLE_CURRENCIES = [("BTC", "bitcoins"), ("USD", "US dollar")]
+
 class ModelForm(forms.ModelForm):
     class Meta:
         model = models.Model
         fields = []
 
-    price_net = MoneyField(default_currency="BTC")
+    price_net = MoneyField(available_currencies=AVAILABLE_CURRENCIES)
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ class Model(models.Model):
     price_gross = MoneyField(
         amount_field="price_gross_amount", currency_field="currency"
     )
-    price = TaxedMoneyField(net_field="price_net", gross_field="price_gross")
+    price = TaxedMoneyField(
+        net_amount_field="price_net_amount",
+        gross_amount_field="price_gross_amount",
+        currency="currency",
+    )
 ```
 
 And forms:
@@ -143,7 +147,16 @@ Updated code:
 
 7. Run `python manage.py makemigrations` and `python manage.py migrate`.
 
-8. In your forms, remove the `currency` argument and add `available_currencies` with available choices. If the form specified `MoneyFields` in `fields` option, replace those with explicit declarations instead:
+8. Change `TaxedMoneyField` declaration:
+```python
+    price = TaxedMoneyField(
+        net_amount_field="price_net_amount",
+        gross_amount_field="price_gross_amount",
+        currency="currency",
+    )
+```
+
+9. In your forms, remove the `currency` argument and add `available_currencies` with available choices. If the form specified `MoneyFields` in `fields` option, replace those with explicit declarations instead:
 ```python
 AVAILABLE_CURRENCIES = [("BTC", "bitcoins"), ("USD", "US dollar")]
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ to the
 
 7. Run `python manage.py makemigrations` and `python manage.py migrate`.
 
-8. If you use forms, change `currency` to `default_currency` (if you need) and remove `MoneyField` from `ModelForm`'s fields list; you should declare it explicitly:
+8. If you use forms, change `currency` to `default_currency`, add (if you need) list `available_currencies` and remove `MoneyField` from `ModelForm`'s fields list; you should declare it explicitly:
 ```python
 class ModelForm(forms.ModelForm):
     class Meta:

--- a/README.md
+++ b/README.md
@@ -119,11 +119,11 @@ Updated code:
     price_net = models.DecimalField("net", default="5", max_digits=9, decimal_places=2)
 ```
 
-2. Replace all occurrences of `MoneyField` by `DecimalField` in your **migration** files (and remove `currency` argument from them); change
+2. Replace all occurrences of the `MoneyField` with `DecimalField` in your **migration** files and remove `currency` argument from them:
 ```python
     field=django_prices.models.MoneyField(currency='BTC', decimal_places=2, default='5', max_digits=9, verbose_name='net')
 ```
-to the
+Updated code:
 ```python
     field=models.DecimalField(decimal_places=2, default='5', max_digits=9, verbose_name='net')
 ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ class DonateForm(forms.Form):
                     MaxMoneyValidator(Money(500, 'EUR'))])
 ```
 
-And for multi-currency:
+The above fields allow to store money in one currency in the table. To store money with different currencies in one table, use the following fields:
 
 ```python
 from django.db import models
@@ -74,7 +74,7 @@ class Product(models.Model):
     price = TaxedMoneyField(net_field="price_net", gross_field="price_gross")
 ```
 
-And templates:
+It also provides support for templates:
 
 ```html+django
 {% load prices %}

--- a/django_prices/forms.py
+++ b/django_prices/forms.py
@@ -9,7 +9,7 @@ from .validators import (
     MoneyPrecisionValidator,
     ValidationError,
 )
-from .widgets import MoneyConstCurrencyInput, MoneyInput
+from .widgets import FixedCurrencyMoneyInput, MoneyInput
 
 __all__ = ("MoneyField", "MoneyInput")
 
@@ -37,7 +37,7 @@ class MoneyField(forms.MultiValueField):
                 isinstance(widget_instance, MoneyInput)
                 and len(available_currencies) <= 1
             ):
-                widget_instance = MoneyConstCurrencyInput(
+                widget_instance = FixedCurrencyMoneyInput(
                     currency=available_currencies[0]
                     if len(available_currencies) == 1
                     else "",

--- a/django_prices/forms.py
+++ b/django_prices/forms.py
@@ -3,8 +3,13 @@ import itertools
 from django import forms
 from prices import Money
 
-from .validators import MaxMoneyValidator, MinMoneyValidator, MoneyPrecisionValidator
-from .widgets import MoneyInput
+from .validators import (
+    MaxMoneyValidator,
+    MinMoneyValidator,
+    MoneyPrecisionValidator,
+    ValidationError,
+)
+from .widgets import MoneyConstCurrencyInput, MoneyInput
 
 __all__ = ("MoneyField", "MoneyInput")
 
@@ -13,6 +18,7 @@ class MoneyField(forms.MultiValueField):
     def __init__(
         self,
         default_currency,
+        available_currencies=None,
         widget=MoneyInput,
         max_value=None,
         min_value=None,
@@ -22,9 +28,28 @@ class MoneyField(forms.MultiValueField):
         *args,
         **kwargs
     ):
-        self.default_currency = default_currency or ""
-        fields = (forms.DecimalField(), forms.CharField())
-        super(MoneyField, self).__init__(fields, widget=widget, *args, **kwargs)
+        self.default_currency = default_currency
+
+        if isinstance(widget, type):
+            widget_instance = widget(available_currencies)
+            if isinstance(widget_instance, MoneyInput) and (
+                available_currencies is None or len(available_currencies) <= 1
+            ):
+                widget_instance = MoneyConstCurrencyInput(
+                    currency=default_currency, attrs={"type": "number", "step": "any"}
+                )
+
+        if available_currencies:
+            fields = (
+                forms.DecimalField(),
+                forms.ChoiceField(choices=available_currencies),
+            )
+        else:
+            fields = (forms.DecimalField(), forms.CharField())
+
+        super(MoneyField, self).__init__(
+            fields, widget=widget_instance, *args, **kwargs
+        )
 
         self.validators = list(itertools.chain(self.default_validators, validators))
         self.validators.append(MoneyPrecisionValidator(max_digits, decimal_places))
@@ -34,6 +59,12 @@ class MoneyField(forms.MultiValueField):
             self.validators.append(MinMoneyValidator(min_value))
 
     def compress(self, data_list):
-        if len(data_list) != 2:
-            return Money(0, self.default_currency)
-        return Money(data_list[0], data_list[1])
+        if data_list:
+            # Raise a validation error if one of the values are empty
+            # (it is possible if field has required=False)
+            if data_list[0] in self.empty_values:
+                raise ValidationError("Enter a valid amount of money")
+            if data_list[1] in self.empty_values:
+                raise ValidationError("Enter a valid currency code")
+            return Money(data_list[0], data_list[1])
+        return None

--- a/django_prices/forms.py
+++ b/django_prices/forms.py
@@ -17,8 +17,7 @@ __all__ = ("MoneyField", "MoneyInput")
 class MoneyField(forms.MultiValueField):
     def __init__(
         self,
-        default_currency,
-        available_currencies=None,
+        available_currencies,
         widget=MoneyInput,
         max_value=None,
         min_value=None,
@@ -28,24 +27,20 @@ class MoneyField(forms.MultiValueField):
         *args,
         **kwargs
     ):
-        self.default_currency = default_currency
-
+        fields = (forms.DecimalField(), forms.ChoiceField(choices=available_currencies))
         if isinstance(widget, type):
             widget_instance = widget(available_currencies)
-            if isinstance(widget_instance, MoneyInput) and (
-                available_currencies is None or len(available_currencies) <= 1
+            if (
+                isinstance(widget_instance, MoneyInput)
+                and len(available_currencies) <= 1
             ):
                 widget_instance = MoneyConstCurrencyInput(
-                    currency=default_currency, attrs={"type": "number", "step": "any"}
+                    currency=available_currencies[0]
+                    if len(available_currencies) == 1
+                    else "",
+                    attrs={"type": "number", "step": "any"},
                 )
-
-        if available_currencies:
-            fields = (
-                forms.DecimalField(),
-                forms.ChoiceField(choices=available_currencies),
-            )
-        else:
-            fields = (forms.DecimalField(), forms.CharField())
+                fields = (forms.DecimalField(), forms.CharField())
 
         super(MoneyField, self).__init__(
             fields, widget=widget_instance, *args, **kwargs

--- a/django_prices/forms.py
+++ b/django_prices/forms.py
@@ -62,7 +62,7 @@ class MoneyField(forms.MultiValueField):
 
     def compress(self, data_list):
         if data_list:
-            # Raise a validation error if one of the values are empty
+            # Raise a validation error if any of the values is empty
             # (it is possible if field has required=False)
             if data_list[0] in self.empty_values:
                 raise ValidationError("Enter a valid amount of money")

--- a/django_prices/models.py
+++ b/django_prices/models.py
@@ -149,3 +149,83 @@ class TaxedMoneyField(object):
         # is_relation = False, but we rely on our net and gross fields for
         # actual validation.
         return value
+
+
+class MoneyCurrencyField:
+
+    description = (
+        "A field that combines an amount of money and currency code into Money"
+        "It allows to store prices with different currencies in one database."
+    )
+    empty_values = list(validators.EMPTY_VALUES)
+
+    # Field flags
+    auto_created = False
+    blank = True
+    concrete = False
+    editable = False
+
+    is_relation = False
+    remote_field = None
+
+    def __init__(
+        self,
+        amount_field="price_amount",
+        currency_field="price_currency",
+        verbose_name=None,
+        **kwargs
+    ):
+        self.amount_field = amount_field
+        self.currency_field = currency_field
+
+        self.column = None
+        self.primary_key = False
+
+        self.creation_counter = Field.creation_counter
+        Field.creation_counter += 1
+
+    def __str__(self):
+        return "MoneyCurrencyField(amount_field=%s, currency_field=%s)" % (
+            self.amount_field,
+            self.currency_field,
+        )
+
+    def __get__(self, instance, cls=None):
+        if instance is None:
+            return self
+        amount = getattr(instance, self.amount_field)
+        currency = getattr(instance, self.currency_field)
+        return Money(amount, currency)
+
+    def __hash__(self):
+        return hash(self.creation_counter)
+
+    def __set__(self, instance, value):
+        amount = None
+        currency = None
+        if value is not None:
+            amount = value.amount
+            currency = value.currency
+        setattr(instance, self.amount_field, amount)
+        setattr(instance, self.currency_field, currency)
+
+    def __eq__(self, other):
+        if isinstance(other, (Field, MoneyCurrencyField)):
+            return self.creation_counter == other.creation_counter
+        return NotImplemented
+
+    def __lt__(self, other):
+        if isinstance(other, (Field, MoneyCurrencyField)):
+            return self.creation_counter < other.creation_counter
+        return NotImplemented
+
+    def contribute_to_class(self, cls, name, **kwargs):
+        self.attname = self.name = name
+        self.model = cls
+        cls._meta.add_field(self, private=True)
+        setattr(cls, name, self)
+
+    def clean(self, value, model_instance):
+        # Shortcircut clean() because Django calls it on all fields with
+        # is_relation = False
+        return value

--- a/django_prices/models.py
+++ b/django_prices/models.py
@@ -123,33 +123,39 @@ class TaxedMoneyField(NonDatabaseFieldBase):
 
     def __init__(
         self,
-        net_field="price_net",
-        gross_field="price_gross",
+        net_amount_field="price_amount_net",
+        gross_amount_field="price_amount_gross",
+        currency="currency",
         verbose_name=None,
         **kwargs
     ):
         super(TaxedMoneyField, self).__init__()
-        self.net_field = net_field
-        self.gross_field = gross_field
+        self.net_amount_field = net_amount_field
+        self.gross_amount_field = gross_amount_field
+        self.currency = currency
 
     def __str__(self):
-        return "TaxedMoneyField(net_field=%s, gross_field=%s)" % (
-            self.net_field,
-            self.gross_field,
+        return (
+            "TaxedMoneyField(net_amount_field=%s, gross_amount_field=%s, currency=%s)"
+            % (self.net_amount_field, self.gross_amount_field, self.currency)
         )
 
     def __get__(self, instance, cls=None):
         if instance is None:
             return self
-        net_val = getattr(instance, self.net_field)
-        gross_val = getattr(instance, self.gross_field)
-        return TaxedMoney(net_val, gross_val)
+        net_amount = getattr(instance, self.net_amount_field)
+        gross_amount = getattr(instance, self.gross_amount_field)
+        currency = getattr(instance, self.currency)
+        return TaxedMoney(Money(net_amount, currency), Money(gross_amount, currency))
 
     def __set__(self, instance, value):
-        net = None
-        gross = None
+        net_amount = None
+        gross_amount = None
+        currency = None
         if value is not None:
-            net = value.net
-            gross = value.gross
-        setattr(instance, self.net_field, net)
-        setattr(instance, self.gross_field, gross)
+            net_amount = value.net.amount
+            gross_amount = value.gross.amount
+            currency = value.gross.currency
+        setattr(instance, self.net_amount_field, net_amount)
+        setattr(instance, self.gross_amount_field, gross_amount)
+        setattr(instance, self.currency, currency)

--- a/django_prices/models.py
+++ b/django_prices/models.py
@@ -129,12 +129,12 @@ class TaxedMoneyField(object):
         setattr(instance, self.gross_field, gross)
 
     def __eq__(self, other):
-        if isinstance(other, (Field, TaxedMoneyField)):
+        if isinstance(other, (Field, MoneyCurrencyField, TaxedMoneyField)):
             return self.creation_counter == other.creation_counter
         return NotImplemented
 
     def __lt__(self, other):
-        if isinstance(other, (Field, TaxedMoneyField)):
+        if isinstance(other, (Field, MoneyCurrencyField, TaxedMoneyField)):
             return self.creation_counter < other.creation_counter
         return NotImplemented
 
@@ -210,12 +210,12 @@ class MoneyCurrencyField:
         setattr(instance, self.currency_field, currency)
 
     def __eq__(self, other):
-        if isinstance(other, (Field, MoneyCurrencyField)):
+        if isinstance(other, (Field, MoneyCurrencyField, TaxedMoneyField)):
             return self.creation_counter == other.creation_counter
         return NotImplemented
 
     def __lt__(self, other):
-        if isinstance(other, (Field, MoneyCurrencyField)):
+        if isinstance(other, (Field, MoneyCurrencyField, TaxedMoneyField)):
             return self.creation_counter < other.creation_counter
         return NotImplemented
 

--- a/django_prices/models.py
+++ b/django_prices/models.py
@@ -1,4 +1,5 @@
 import itertools
+from decimal import Decimal
 
 from django.core import validators
 from django.db import models
@@ -10,67 +11,105 @@ from . import forms
 from .validators import MoneyPrecisionValidator
 
 
-class MoneyField(models.DecimalField):
+class MoneyField:
 
-    description = "A field that stores an amount of money"
+    description = (
+        "A field that combines an amount of money and currency code into Money"
+        "It allows to store prices with different currencies in one database."
+    )
+    empty_values = list(validators.EMPTY_VALUES)
 
-    def __init__(self, verbose_name=None, currency=None, **kwargs):
-        self.currency = currency
-        super(MoneyField, self).__init__(verbose_name, **kwargs)
+    # Field flags
+    auto_created = False
+    blank = True
+    concrete = False
+    editable = False
 
-    def from_db_value(self, value, expression, connection, context):
-        return self.to_python(value)
+    is_relation = False
+    remote_field = None
 
-    def to_python(self, value):
-        if isinstance(value, Money):
-            if value.currency != self.currency:
-                raise ValueError(
-                    "Invalid currency: %r (expected %r)"
-                    % (value.currency, self.currency)
-                )
-            return value
-        value = super(MoneyField, self).to_python(value)
-        if value is None:
-            return value
-        return Money(value, self.currency)
+    def __init__(
+        self,
+        amount_field="price_amount",
+        currency_field="price_currency",
+        verbose_name=None,
+        **kwargs
+    ):
+        self.amount_field = amount_field
+        self.currency_field = currency_field
 
-    def get_prep_value(self, value):
-        value = self.to_python(value)
+        self.column = None
+        self.primary_key = False
+
+        self.creation_counter = Field.creation_counter
+        Field.creation_counter += 1
+
+    def __str__(self):
+        return "MoneyField(amount_field=%s, currency_field=%s)" % (
+            self.amount_field,
+            self.currency_field,
+        )
+
+    def __get__(self, instance, cls=None):
+        if instance is None:
+            return self
+
+        amount = getattr(instance, self.amount_field)
+        currency = getattr(instance, self.currency_field)
+        if amount and currency:
+            return Money(amount, currency)
+        return self.get_default()
+
+    def __hash__(self):
+        return hash(self.creation_counter)
+
+    def __set__(self, instance, value):
+        amount = None
+        currency = None
         if value is not None:
-            return value.amount
+            amount = value.amount
+            currency = value.currency
+        setattr(instance, self.amount_field, amount)
+        setattr(instance, self.currency_field, currency)
+
+    def __eq__(self, other):
+        if isinstance(other, (Field, MoneyField, TaxedMoneyField)):
+            return self.creation_counter == other.creation_counter
+        return NotImplemented
+
+    def __lt__(self, other):
+        if isinstance(other, (Field, MoneyField, TaxedMoneyField)):
+            return self.creation_counter < other.creation_counter
+        return NotImplemented
+
+    def contribute_to_class(self, cls, name, **kwargs):
+        self.attname = self.name = name
+        self.model = cls
+        cls._meta.add_field(self, private=True)
+        setattr(cls, name, self)
+
+    def clean(self, value, model_instance):
+        # Shortcircut clean() because Django calls it on all fields with
+        # is_relation = False
         return value
 
-    def get_db_prep_save(self, value, connection):
-        value = self.get_prep_value(value)
-        db_value = connection.ops.adapt_decimalfield_value
-        return db_value(value, self.max_digits, self.decimal_places)
-
-    def value_to_string(self, obj):
-        value = self.value_from_object(obj)
-        if value is not None:
-            return value
-        return super(MoneyField, self).value_to_string(value)
-
     def formfield(self, **kwargs):
-        defaults = {"currency": self.currency, "form_class": forms.MoneyField}
-        defaults.update(kwargs)
-        return super(MoneyField, self).formfield(**defaults)
+        currency = ""
+        if hasattr(self, "model"):
+            currency = self.model._meta.get_field(self.currency_field).get_default()
+        return forms.MoneyField(default_currency=currency)
 
     def get_default(self):
-        default = super(MoneyField, self).get_default()
-        return self.to_python(default)
+        default_currency = ""
+        default_amount = Decimal(0)
+        if hasattr(self, "model"):
+            default_currency = self.model._meta.get_field(
+                self.currency_field
+            ).get_default()
+            d = self.model._meta.get_field(self.amount_field).get_default()
+            default_amount = self.model._meta.get_field(self.amount_field).to_python(d)
 
-    @cached_property
-    def validators(self):
-        validators = list(itertools.chain(self.default_validators, self._validators))
-        return validators + [
-            MoneyPrecisionValidator(self.currency, self.max_digits, self.decimal_places)
-        ]
-
-    def deconstruct(self):
-        name, path, args, kwargs = super(MoneyField, self).deconstruct()
-        kwargs["currency"] = self.currency
-        return name, path, args, kwargs
+        return Money(default_amount, default_currency)
 
 
 class TaxedMoneyField(object):
@@ -129,12 +168,12 @@ class TaxedMoneyField(object):
         setattr(instance, self.gross_field, gross)
 
     def __eq__(self, other):
-        if isinstance(other, (Field, MoneyCurrencyField, TaxedMoneyField)):
+        if isinstance(other, (Field, MoneyField, TaxedMoneyField)):
             return self.creation_counter == other.creation_counter
         return NotImplemented
 
     def __lt__(self, other):
-        if isinstance(other, (Field, MoneyCurrencyField, TaxedMoneyField)):
+        if isinstance(other, (Field, MoneyField, TaxedMoneyField)):
             return self.creation_counter < other.creation_counter
         return NotImplemented
 
@@ -148,84 +187,4 @@ class TaxedMoneyField(object):
         # Shortcircut clean() because Django calls it on all fields with
         # is_relation = False, but we rely on our net and gross fields for
         # actual validation.
-        return value
-
-
-class MoneyCurrencyField:
-
-    description = (
-        "A field that combines an amount of money and currency code into Money"
-        "It allows to store prices with different currencies in one database."
-    )
-    empty_values = list(validators.EMPTY_VALUES)
-
-    # Field flags
-    auto_created = False
-    blank = True
-    concrete = False
-    editable = False
-
-    is_relation = False
-    remote_field = None
-
-    def __init__(
-        self,
-        amount_field="price_amount",
-        currency_field="price_currency",
-        verbose_name=None,
-        **kwargs
-    ):
-        self.amount_field = amount_field
-        self.currency_field = currency_field
-
-        self.column = None
-        self.primary_key = False
-
-        self.creation_counter = Field.creation_counter
-        Field.creation_counter += 1
-
-    def __str__(self):
-        return "MoneyCurrencyField(amount_field=%s, currency_field=%s)" % (
-            self.amount_field,
-            self.currency_field,
-        )
-
-    def __get__(self, instance, cls=None):
-        if instance is None:
-            return self
-        amount = getattr(instance, self.amount_field)
-        currency = getattr(instance, self.currency_field)
-        return Money(amount, currency)
-
-    def __hash__(self):
-        return hash(self.creation_counter)
-
-    def __set__(self, instance, value):
-        amount = None
-        currency = None
-        if value is not None:
-            amount = value.amount
-            currency = value.currency
-        setattr(instance, self.amount_field, amount)
-        setattr(instance, self.currency_field, currency)
-
-    def __eq__(self, other):
-        if isinstance(other, (Field, MoneyCurrencyField, TaxedMoneyField)):
-            return self.creation_counter == other.creation_counter
-        return NotImplemented
-
-    def __lt__(self, other):
-        if isinstance(other, (Field, MoneyCurrencyField, TaxedMoneyField)):
-            return self.creation_counter < other.creation_counter
-        return NotImplemented
-
-    def contribute_to_class(self, cls, name, **kwargs):
-        self.attname = self.name = name
-        self.model = cls
-        cls._meta.add_field(self, private=True)
-        setattr(cls, name, self)
-
-    def clean(self, value, model_instance):
-        # Shortcircut clean() because Django calls it on all fields with
-        # is_relation = False
         return value

--- a/django_prices/models.py
+++ b/django_prices/models.py
@@ -155,7 +155,7 @@ class TaxedMoneyField(NonDatabaseFieldBase):
         if value is not None:
             net_amount = value.net.amount
             gross_amount = value.gross.amount
-            currency = value.gross.currency
+            currency = value.currency
         setattr(instance, self.net_amount_field, net_amount)
         setattr(instance, self.gross_amount_field, gross_amount)
         setattr(instance, self.currency, currency)

--- a/django_prices/models.py
+++ b/django_prices/models.py
@@ -98,16 +98,12 @@ class MoneyField(NonDatabaseFieldBase):
         setattr(instance, self.currency_field, currency)
 
     def formfield(self, **kwargs):
-        currency = ""
         available_currencies = []
         if hasattr(self, "model"):
-            currency = self.model._meta.get_field(self.currency_field).get_default()
             available_currencies = self.model._meta.get_field(
                 self.currency_field
             ).choices
-        return forms.MoneyField(
-            default_currency=currency, available_currencies=available_currencies
-        )
+        return forms.MoneyField(available_currencies=available_currencies)
 
     def get_default(self):
         default_currency = ""

--- a/django_prices/models.py
+++ b/django_prices/models.py
@@ -106,14 +106,13 @@ class MoneyField(NonDatabaseFieldBase):
         return forms.MoneyField(available_currencies=available_currencies)
 
     def get_default(self):
-        default_currency = ""
+        default_currency = None
         default_amount = Decimal(0)
         if hasattr(self, "model"):
             default_currency = self.model._meta.get_field(
                 self.currency_field
             ).get_default()
-            d = self.model._meta.get_field(self.amount_field).get_default()
-            default_amount = self.model._meta.get_field(self.amount_field).to_python(d)
+            default_amount = self.model._meta.get_field(self.amount_field).get_default()
 
         return Money(default_amount, default_currency)
 

--- a/django_prices/validators.py
+++ b/django_prices/validators.py
@@ -36,6 +36,8 @@ class MoneyPrecisionValidator(DecimalValidator):
 class MoneyValueValidator:
     def __call__(self, value):
         cleaned = self.clean(value)
+        if cleaned.currency != self.limit_value.currency:
+            return
         if self.compare(cleaned, self.limit_value):
             currency = self.limit_value.currency
             params = {

--- a/django_prices/validators.py
+++ b/django_prices/validators.py
@@ -11,21 +11,16 @@ from .templatetags.prices_i18n import format_price
 
 
 class MoneyPrecisionValidator(DecimalValidator):
-    def __init__(self, currency, *args):
-        self.currency = currency
+    def __init__(self, *args):
         super(MoneyPrecisionValidator, self).__init__(*args)
 
     def __call__(self, other):
-        if self.currency != other.currency:
-            raise ValueError(
-                "Invalid currency: %r (expected %r)" % (other.currency, self.currency)
-            )
-
         value = other.amount
+        currency = other.currency
         super(MoneyPrecisionValidator, self).__call__(value)
 
-        if is_currency(self.currency):
-            currency_precision = get_currency_precision(self.currency)
+        if is_currency(currency):
+            currency_precision = get_currency_precision(currency)
             exponent = value.as_tuple()[-1]
             if exponent >= 0:
                 decimals = 0

--- a/django_prices/validators.py
+++ b/django_prices/validators.py
@@ -1,5 +1,4 @@
 from babel.numbers import get_currency_precision, is_currency
-
 from django.core.validators import (
     DecimalValidator,
     MaxValueValidator,

--- a/django_prices/widgets.py
+++ b/django_prices/widgets.py
@@ -2,7 +2,7 @@ from django import forms
 from django.template.loader import render_to_string
 from prices import Money
 
-__all__ = ["MoneyInput", "MoneyConstCurrencyInput"]
+__all__ = ["MoneyInput", "FixedCurrencyMoneyInput"]
 
 
 class MoneyInput(forms.MultiWidget):
@@ -21,23 +21,23 @@ class MoneyInput(forms.MultiWidget):
         return [None, None]
 
 
-class MoneyConstCurrencyInput(forms.MultiWidget):
+class FixedCurrencyMoneyInput(forms.MultiWidget):
     template = "prices/widget.html"
 
     def __init__(self, currency, attrs=None):
         self.currency = currency
         widgets = [forms.TextInput(attrs={"type": "number", "step": "any"})]
-        super(MoneyConstCurrencyInput, self).__init__(widgets, attrs)
+        super(FixedCurrencyMoneyInput, self).__init__(widgets, attrs)
 
     def decompress(self, value):
         if value and isinstance(value, Money):
             return [value.amount, self.currency]
         if value and isinstance(value, (list, tuple)) and len(value) == 2:
             return [value[0], self.currency]
-        return [None, self.currency]
+        return [None, None]
 
     def render(self, name, value, attrs=None, renderer=None):
-        widget = super(MoneyConstCurrencyInput, self).render(
+        widget = super(FixedCurrencyMoneyInput, self).render(
             name, value, attrs=attrs, renderer=renderer
         )
         return render_to_string(

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -6,27 +6,40 @@ from django_prices.validators import MaxMoneyValidator, MinMoneyValidator
 
 from . import models
 
+AVAILABLE_CURRENCIES = [("BTC", "bitcoins"), ("USD", "US dollar")]
+
 
 class ModelForm(forms.ModelForm):
     class Meta:
         model = models.Model
         fields = []
 
-    price_net = MoneyField(default_currency="BTC")
-    price_gross = MoneyField(default_currency="BTC")
+    price_net = MoneyField(
+        default_currency="BTC", available_currencies=AVAILABLE_CURRENCIES
+    )
+    price_gross = MoneyField(
+        default_currency="BTC", available_currencies=AVAILABLE_CURRENCIES
+    )
 
 
 class RequiredPriceForm(forms.Form):
-    price_net = MoneyField(default_currency="BTC")
+    price_net = MoneyField(
+        default_currency="BTC", available_currencies=AVAILABLE_CURRENCIES
+    )
 
 
 class OptionalPriceForm(forms.Form):
-    price_net = MoneyField(default_currency="BTC", required=False)
+    price_net = MoneyField(
+        default_currency="BTC",
+        available_currencies=AVAILABLE_CURRENCIES,
+        required=False,
+    )
 
 
 class ValidatedPriceForm(forms.Form):
     price = MoneyField(
         default_currency="USD",
+        available_currencies=AVAILABLE_CURRENCIES,
         max_digits=9,
         decimal_places=2,
         validators=[

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -36,3 +36,11 @@ class ValidatedPriceForm(forms.Form):
             MaxMoneyValidator(Money(15, currency="USD")),
         ],
     )
+
+
+class MaxMinPriceForm(forms.Form):
+    price = MoneyField(
+        available_currencies=AVAILABLE_CURRENCIES,
+        min_values=[Money(5, currency="USD"), Money(6, currency="BTC")],
+        max_values=[Money(15, currency="USD"), Money(16, currency="BTC")],
+    )

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -10,20 +10,23 @@ from . import models
 class ModelForm(forms.ModelForm):
     class Meta:
         model = models.Model
-        fields = ["price_net", "price_gross"]
+        fields = []
+
+    price_net = MoneyField(default_currency="BTC")
+    price_gross = MoneyField(default_currency="BTC")
 
 
 class RequiredPriceForm(forms.Form):
-    price_net = MoneyField(currency="BTC")
+    price_net = MoneyField(default_currency="BTC")
 
 
 class OptionalPriceForm(forms.Form):
-    price_net = MoneyField(currency="BTC", required=False)
+    price_net = MoneyField(default_currency="BTC", required=False)
 
 
 class ValidatedPriceForm(forms.Form):
     price = MoneyField(
-        currency="USD",
+        default_currency="USD",
         max_digits=9,
         decimal_places=2,
         validators=[

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -14,31 +14,20 @@ class ModelForm(forms.ModelForm):
         model = models.Model
         fields = []
 
-    price_net = MoneyField(
-        default_currency="BTC", available_currencies=AVAILABLE_CURRENCIES
-    )
-    price_gross = MoneyField(
-        default_currency="BTC", available_currencies=AVAILABLE_CURRENCIES
-    )
+    price_net = MoneyField(available_currencies=AVAILABLE_CURRENCIES)
+    price_gross = MoneyField(available_currencies=AVAILABLE_CURRENCIES)
 
 
 class RequiredPriceForm(forms.Form):
-    price_net = MoneyField(
-        default_currency="BTC", available_currencies=AVAILABLE_CURRENCIES
-    )
+    price_net = MoneyField(available_currencies=AVAILABLE_CURRENCIES)
 
 
 class OptionalPriceForm(forms.Form):
-    price_net = MoneyField(
-        default_currency="BTC",
-        available_currencies=AVAILABLE_CURRENCIES,
-        required=False,
-    )
+    price_net = MoneyField(available_currencies=AVAILABLE_CURRENCIES, required=False)
 
 
 class ValidatedPriceForm(forms.Form):
     price = MoneyField(
-        default_currency="USD",
         available_currencies=AVAILABLE_CURRENCIES,
         max_digits=9,
         decimal_places=2,

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django_prices.models import MoneyField, TaxedMoneyField
+from django_prices.models import MoneyCurrencyField, MoneyField, TaxedMoneyField
 
 
 class Model(models.Model):
@@ -10,3 +10,16 @@ class Model(models.Model):
         "gross", currency="BTC", default="5", max_digits=9, decimal_places=2
     )
     price = TaxedMoneyField(net_field="price_net", gross_field="price_gross")
+
+
+class CurrencyModel(models.Model):
+    currency = models.CharField(max_length=3, default="BTC")
+    money_net_amount = models.DecimalField(max_digits=9, decimal_places=2)
+    money_net = MoneyCurrencyField(
+        amount_field="money_net_amount", currency_field="currency"
+    )
+    money_gross_amount = models.DecimalField(max_digits=9, decimal_places=2)
+    money_gross = MoneyCurrencyField(
+        amount_field="money_gross_amount", currency_field="currency"
+    )
+    taxed_money = TaxedMoneyField(net_field="money_net", gross_field="money_gross")

--- a/tests/models.py
+++ b/tests/models.py
@@ -16,4 +16,8 @@ class Model(models.Model):
     price_gross = MoneyField(
         amount_field="price_gross_amount", currency_field="currency"
     )
-    price = TaxedMoneyField(net_field="price_net", gross_field="price_gross")
+    price = TaxedMoneyField(
+        net_amount_field="price_net_amount",
+        gross_amount_field="price_gross_amount",
+        currency="currency",
+    )

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,9 +1,13 @@
 from django.db import models
 from django_prices.models import MoneyField, TaxedMoneyField
 
+AVAILABLE_CURRENCIES = [("BTC", "bitcoins"), ("USD", "US dollar")]
+
 
 class Model(models.Model):
-    currency = models.CharField(max_length=3, default="BTC")
+    currency = models.CharField(
+        max_length=3, default="BTC", choices=AVAILABLE_CURRENCIES
+    )
     price_net_amount = models.DecimalField(max_digits=9, decimal_places=2, default="5")
     price_net = MoneyField(amount_field="price_net_amount", currency_field="currency")
     price_gross_amount = models.DecimalField(

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,25 +1,15 @@
 from django.db import models
-from django_prices.models import MoneyCurrencyField, MoneyField, TaxedMoneyField
+from django_prices.models import MoneyField, TaxedMoneyField
 
 
 class Model(models.Model):
-    price_net = MoneyField(
-        "net", currency="BTC", default="5", max_digits=9, decimal_places=2
+    currency = models.CharField(max_length=3, default="BTC")
+    price_net_amount = models.DecimalField(max_digits=9, decimal_places=2, default="5")
+    price_net = MoneyField(amount_field="price_net_amount", currency_field="currency")
+    price_gross_amount = models.DecimalField(
+        max_digits=9, decimal_places=2, default="5"
     )
     price_gross = MoneyField(
-        "gross", currency="BTC", default="5", max_digits=9, decimal_places=2
+        amount_field="price_gross_amount", currency_field="currency"
     )
     price = TaxedMoneyField(net_field="price_net", gross_field="price_gross")
-
-
-class CurrencyModel(models.Model):
-    currency = models.CharField(max_length=3, default="BTC")
-    money_net_amount = models.DecimalField(max_digits=9, decimal_places=2)
-    money_net = MoneyCurrencyField(
-        amount_field="money_net_amount", currency_field="currency"
-    )
-    money_gross_amount = models.DecimalField(max_digits=9, decimal_places=2)
-    money_gross = MoneyCurrencyField(
-        amount_field="money_gross_amount", currency_field="currency"
-    )
-    taxed_money = TaxedMoneyField(net_field="money_net", gross_field="money_gross")

--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -6,8 +6,7 @@ from decimal import Decimal
 
 import pytest
 from django.core.exceptions import ValidationError
-from django.db import connection
-from django.db.models import CharField, DecimalField
+from django.db.models import DecimalField
 from django.utils import translation
 from django_prices import forms, widgets
 from django_prices.models import MoneyField, TaxedMoneyField
@@ -33,21 +32,6 @@ from .models import Model
 @pytest.fixture(scope="module")
 def money_fixture():
     return Money("10", "USD")
-
-
-@pytest.fixture(scope="module")
-def money_with_decimals():
-    return Money("10.20", "USD")
-
-
-@pytest.fixture(scope="module")
-def price_fixture():
-    return TaxedMoney(net=Money("10", "USD"), gross=Money("15", "USD"))
-
-
-@pytest.fixture(scope="module")
-def price_with_decimals():
-    return TaxedMoney(net=Money("10.20", "USD"), gross=Money("15", "USD"))
 
 
 def test_money_field_init():

--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -7,9 +7,10 @@ from decimal import Decimal
 import pytest
 from django.core.exceptions import ValidationError
 from django.db import connection
+from django.db.models import CharField, DecimalField
 from django.utils import translation
 from django_prices import forms, widgets
-from django_prices.models import MoneyCurrencyField, MoneyField, TaxedMoneyField
+from django_prices.models import MoneyField, TaxedMoneyField
 from django_prices.templatetags import prices, prices_i18n
 from django_prices.validators import (
     MaxMoneyValidator,
@@ -19,7 +20,7 @@ from django_prices.validators import (
 from prices import Money, TaxedMoney, percentage_discount
 
 from .forms import ModelForm, OptionalPriceForm, RequiredPriceForm, ValidatedPriceForm
-from .models import CurrencyModel, Model
+from .models import Model
 
 
 @pytest.fixture(scope="module")
@@ -43,74 +44,67 @@ def price_with_decimals():
 
 
 def test_money_field_init():
-    field = MoneyField(currency="BTC", default="5", max_digits=9, decimal_places=2)
-    assert field.get_default() == Money(5, "BTC")
-
-
-def test_money_field_get_prep_value():
-    field = MoneyField(
-        "price", currency="BTC", default="5", max_digits=9, decimal_places=2
-    )
-    assert field.get_prep_value(Money(5, "BTC")) == Decimal(5)
-
-
-def test_money_field_get_db_prep_save():
-    field = MoneyField(
-        "price", currency="BTC", default="5", max_digits=9, decimal_places=2
-    )
-    value = field.get_db_prep_save(Money(5, "BTC"), connection)
-    assert value == "5.00"
-
-
-def test_money_field_value_to_string():
-    instance = Model(price_net=30)
-    field = instance._meta.get_field("price_net")
-    assert field.value_to_string(instance) == Decimal("30")
-
-
-def test_money_field_from_db_value():
-    field = MoneyField(
-        "price", currency="BTC", default="5", max_digits=9, decimal_places=2
-    )
-    assert field.from_db_value(7, None, None, None) == Money(7, "BTC")
-
-
-def test_money_field_from_db_value_handles_none():
-    field = MoneyField(
-        "price", currency="BTC", default="5", max_digits=9, decimal_places=2
-    )
-    assert field.from_db_value(None, None, None, None) is None
-
-
-def test_money_field_from_db_value_checks_currency():
-    field = MoneyField(
-        "price", currency="BTC", default="5", max_digits=9, decimal_places=2
-    )
-    invalid = Money(1, "USD")
-    with pytest.raises(ValueError):
-        field.from_db_value(invalid, None, None, None)
-
-
-def test_money_field_from_db_value_checks_min_value():
-    field = MoneyField(
-        "price", currency="BTC", default="5", max_digits=9, decimal_places=2
-    )
-    invalid = Money(1, "USD")
-    with pytest.raises(ValueError):
-        field.from_db_value(invalid, None, None, None)
+    field = MoneyField(amount_field="amount", currency_field="currency")
+    assert field.get_default() == Money(0, "")
+    assert field.amount_field == "amount"
+    assert field.currency_field == "currency"
 
 
 def test_money_field_formfield():
-    field = MoneyField(
-        "price", currency="BTC", default="5", max_digits=9, decimal_places=2
-    )
+    field = MoneyField(amount_field="amount", currency_field="currency")
+    # field = MoneyField("price", default=Money(5, "BTC"), max_digits=9, decimal_places=2)
     form_field = field.formfield()
     assert isinstance(form_field, forms.MoneyField)
-    assert form_field.currency == "BTC"
+    # assert form_field.currency == ""
     assert isinstance(form_field.widget, widgets.MoneyInput)
+    # assert
 
 
-def test_price_field_init():
+def test_compare_money_field_with_same_type_field():
+    field_1 = MoneyField(amount_field="money_net_amount", currency_field="currency")
+    field_2 = MoneyField(amount_field="money_net_amount", currency_field="currency")
+
+    # Comparision is based on creation_counter attribute
+    assert field_1 < field_2
+    field_2.creation_counter -= 1
+    assert field_1 == field_2
+
+
+def test_compare_money_field_with_django_field():
+    field_1 = MoneyField(amount_field="money_net_amount", currency_field="currency")
+    field_2 = DecimalField(default="5", max_digits=9, decimal_places=2)
+
+    # Comparision is based on creation_counter attribute
+    assert field_1 < field_2
+    field_2.creation_counter -= 1
+    assert field_1 == field_2
+
+
+def test_compare_money_field_with_taxed_money_field():
+    field_1 = MoneyField(amount_field="money_net_amount", currency_field="currency")
+    field_2 = TaxedMoneyField(net_field="price_net", gross_field="price_gross")
+
+    # Comparision is based on creation_counter attribute
+    assert field_1 < field_2
+    field_2.creation_counter -= 1
+    assert field_1 == field_2
+
+
+def test_money_field_instance_values():
+    instance = Model(price_net_amount=Decimal("10"), currency="USD")
+    assert instance.price_net.amount == Decimal("10")
+    assert instance.price_net.currency == "USD"
+    assert instance.price_net == Money("10", "USD")
+
+
+def test_money_field_set_instance_values():
+    instance = Model()
+    instance.price_net = Money(25, "USD")
+    assert instance.price_net_amount == 25
+    assert instance.currency == "USD"
+
+
+def test_taxed_money_field_init():
     field = TaxedMoneyField(net_field="price_net", gross_field="price_gross")
     assert field.net_field == "price_net"
     assert field.gross_field == "price_gross"
@@ -128,7 +122,7 @@ def test_compare_taxed_money_field_with_same_type_field():
 
 def test_compare_taxed_money_field_with_django_field():
     field_1 = TaxedMoneyField(net_field="price_net", gross_field="price_gross")
-    field_2 = MoneyField(currency="BTC", default="5", max_digits=9, decimal_places=2)
+    field_2 = DecimalField(default="5", max_digits=9, decimal_places=2)
 
     # Comparision is based on creation_counter attribute
     assert field_1 < field_2
@@ -136,11 +130,9 @@ def test_compare_taxed_money_field_with_django_field():
     assert field_1 == field_2
 
 
-def test_compare_taxed_money_field_with_money_currency_field():
+def test_compare_taxed_money_field_with_money_field():
     field_1 = TaxedMoneyField(net_field="price_net", gross_field="price_gross")
-    field_2 = MoneyCurrencyField(
-        amount_field="money_net_amount", currency_field="currency"
-    )
+    field_2 = MoneyField(amount_field="money_net_amount", currency_field="currency")
     # Comparision is based on creation_counter attribute
     assert field_1 < field_2
     field_2.creation_counter -= 1
@@ -150,56 +142,60 @@ def test_compare_taxed_money_field_with_money_currency_field():
 @pytest.mark.parametrize(
     "data,initial,expected_result",
     [
-        ("5", Money(5, "BTC"), False),
-        ("5", Money(10, "BTC"), True),
-        ("5", "5", False),
-        ("5", "10", True),
-        ("5", None, True),
-        (None, Money(5, "BTC"), True),
-        (None, "5", True),
-        (None, None, False),
+        (["5", "BTC"], Money(5, "BTC"), False),
+        (["5", "BTC"], Money(10, "BTC"), True),
+        (["5", "BTC"], ["5", "BTC"], False),
+        (["5", "BTC"], ["5", "USD"], True),
+        (["5", "BTC"], None, True),
+        # (["5"], Money(10, "BTC"), True)
+        ([None, None], Money(5, "BTC"), True),
+        ([None, None], ["5", "BTC"], True),
+        ([None, None], None, False),
     ],
 )
 def test_form_changed_data(data, initial, expected_result):
-    form = RequiredPriceForm(data={"price_net": data}, initial={"price_net": initial})
+    form = RequiredPriceForm(
+        data={"price_net_0": data[0], "price_net_1": data[1]},
+        initial={"price_net": initial},
+    )
+    assert bool(form.changed_data) == expected_result
+
+
+@pytest.mark.parametrize(
+    "field,value,expected_result",
+    [("price_net_0", "5", True), ("price_net_1", "USD", True)],
+)
+def test_form_changed_one_data(field, value, expected_result):
+    form = RequiredPriceForm(
+        data={field: value}, initial={"price_net": Money(10, "BTC")}
+    )
     assert bool(form.changed_data) == expected_result
 
 
 def test_render():
-    widget = widgets.MoneyInput("BTC", attrs={"type": "number"})
-    result = widget.render("price", 5, attrs={"foo": "bar"})
-    attrs = ['foo="bar"', 'name="price"', 'type="number"', 'value="5"', "BTC"]
+    # widget = widgets.MoneyInput("BTC", attrs={"type": "number"})
+    widget = widgets.MoneyInput(attrs={"key": "value"})
+    result = widget.render("price", Money(5, "BTC"), attrs={"foo": "bar"})
+    attrs = [
+        'foo="bar"',
+        'name="price_0"',
+        'name="price_1"',
+        'key="value"',
+        'value="5"',
+        "BTC",
+    ]
     for attr in attrs:
         assert attr in result
 
 
-def test_instance_values():
-    instance = Model(price_net=Money(25, "BTC"))
+def test_money_instance_values():
+    instance = Model(price_net=Money(25, "USD"))
     assert instance.price.net.amount == 25
 
 
 def test_instance_values_both_amounts():
     instance = Model(price_net=Money(25, "BTC"), price_gross=Money(30, "BTC"))
     assert instance.price == TaxedMoney(net=Money(25, "BTC"), gross=Money(30, "BTC"))
-
-
-def test_instance_values_different_currencies():
-    model = Model(price_net=Money(25, "BTC"), price_gross=Money(30, "USD"))
-    with pytest.raises(ValueError):
-        assert model.price
-
-
-def test_instance_save_values_different_currency(db):
-    model = Model()
-    model.price_gross = Money(10, "USD")
-    with pytest.raises(ValueError):
-        model.save()
-
-
-def test_instance_full_lean_values_different_currency(db):
-    model = Model(price_gross=Money(10, "USD"))
-    with pytest.raises(ValueError):
-        model.full_clean()
 
 
 def test_instance_full_clean_values_invalid_amount(db):
@@ -222,26 +218,33 @@ def test_init_taxedmoney_model_field():
 
 
 def test_init_taxedmoney_model_field_validation():
-    instance = Model(price=TaxedMoney(Money(25, "USD"), Money(30, "USD")))
-    with pytest.raises(ValueError):
+    instance = Model(price=TaxedMoney(Money("25.566", "USD"), Money(30, "USD")))
+    with pytest.raises(ValidationError):
         instance.full_clean()
 
 
 def test_combined_field_validation():
     instance = Model()
-    instance.price = TaxedMoney(Money(25, "USD"), Money(30, "USD"))
-    with pytest.raises(ValueError):
+    instance.price = TaxedMoney(Money("25.7877", "USD"), Money(30, "USD"))
+    with pytest.raises(ValidationError):
         instance.full_clean()
 
 
 def test_field_passes_all_validations():
-    form = RequiredPriceForm(data={"price_net": "20"})
+    form = RequiredPriceForm(data={"price_net_0": "20", "price_net_1": "BTC"})
     form.full_clean()
     assert form.errors == {}
 
 
 def test_model_field_passes_all_validations():
-    form = ModelForm(data={"price_net": "20", "price_gross": "25"})
+    form = ModelForm(
+        data={
+            "price_net_0": "20",
+            "price_net_1": "BTC",
+            "price_gross_0": "25",
+            "price_gross_1": "BTC",
+        }
+    )
     form.full_clean()
     assert form.errors == {}
 
@@ -271,18 +274,16 @@ def test_validate_min_money():
 
 
 def test_validate_money_precision():
-    validator = MoneyPrecisionValidator("USD", 9, 2)
+    validator = MoneyPrecisionValidator(9, 2)
     validator(Money("5.00", "USD"))
     validator(Money("5.1", "USD"))
     with pytest.raises(ValidationError):
         validator(Money("5.001", "USD"))
-    with pytest.raises(ValueError):
-        validator(Money("5.00", "BTC"))
 
 
 def test_validate_money_precision_by_currency():
     # Validator tests if precision is valid for given currency
-    validator = MoneyPrecisionValidator("USD", 9, 3)
+    validator = MoneyPrecisionValidator(9, 3)
     validator(Money("5.00", "USD"))
     validator(Money("5.1", "USD"))
     with pytest.raises(ValidationError):
@@ -290,14 +291,14 @@ def test_validate_money_precision_by_currency():
 
 
 def test_validate_money_precision_fictional_currency():
-    validator = MoneyPrecisionValidator("BTC", 16, 10)
+    validator = MoneyPrecisionValidator(16, 10)
     validator(Money("5.1234567890", "BTC"))
     with pytest.raises(ValidationError):
         validator(Money("5.12345678901", "BTC"))
 
 
 def test_validators_work_with_formfields():
-    form = ValidatedPriceForm(data={"price": "25"})
+    form = ValidatedPriceForm(data={"price_0": "25", "price_1": "USD"})
     form.full_clean()
     assert form.errors == {
         "price": ["Ensure this value is less than or equal to $15.00."]
@@ -381,91 +382,3 @@ def test_get_currency_fraction_unknown_currency():
 def test_format_price_invalid_value():
     result = prices_i18n.format_price("invalid", "USD")
     assert result == ""
-
-
-def test_money_currency_field_init():
-    field = MoneyCurrencyField(
-        amount_field="money_net_amount", currency_field="currency"
-    )
-    assert field.amount_field == "money_net_amount"
-    assert field.currency_field == "currency"
-
-
-def test_compare_money_currency_field_with_same_type_field():
-    field_1 = MoneyCurrencyField(
-        amount_field="money_net_amount", currency_field="currency"
-    )
-    field_2 = MoneyCurrencyField(
-        amount_field="money_net_amount", currency_field="currency"
-    )
-
-    # Comparision is based on creation_counter attribute
-    assert field_1 < field_2
-    field_2.creation_counter -= 1
-    assert field_1 == field_2
-
-
-def test_compare_money_currency_field_with_django_field():
-    field_1 = MoneyCurrencyField(
-        amount_field="money_net_amount", currency_field="currency"
-    )
-    field_2 = MoneyField(currency="BTC", default="5", max_digits=9, decimal_places=2)
-
-    # Comparision is based on creation_counter attribute
-    assert field_1 < field_2
-    field_2.creation_counter -= 1
-    assert field_1 == field_2
-
-
-def test_compare_money_currency_field_with_taxed_money_field():
-    field_1 = MoneyCurrencyField(
-        amount_field="money_net_amount", currency_field="currency"
-    )
-    field_2 = TaxedMoneyField(net_field="price_net", gross_field="price_gross")
-
-    # Comparision is based on creation_counter attribute
-    assert field_1 < field_2
-    field_2.creation_counter -= 1
-    assert field_1 == field_2
-
-
-def test_money_currency_instance_values():
-    instance = CurrencyModel(money_net_amount=Decimal("10"), currency="USD")
-    assert instance.money_net.amount == Decimal("10")
-    assert instance.money_net.currency == "USD"
-    assert instance.money_net == Money("10", "USD")
-
-
-def test_money_currency_set_instance_values():
-    instance = CurrencyModel()
-    instance.money_net = Money(25, "USD")
-    assert instance.money_net_amount == 25
-    assert instance.currency == "USD"
-
-
-def test_taxed_money_currency_instance_values():
-    instance = CurrencyModel(
-        money_net_amount=Decimal("10"), currency="USD", money_gross_amount=Decimal("11")
-    )
-
-    assert instance.money_gross.amount == Decimal("11")
-    assert instance.money_gross.currency == "USD"
-    assert instance.taxed_money.net.amount == Decimal("10")
-    assert instance.taxed_money.net.currency == "USD"
-    assert instance.taxed_money.gross.amount == Decimal("11")
-    assert instance.taxed_money.gross.currency == "USD"
-
-
-def test_taxed_money_currency_set_instance_values():
-    instance = CurrencyModel()
-    instance.taxed_money = TaxedMoney(Money(25, "USD"), Money(30, "USD"))
-    assert instance.money_net_amount == 25
-    assert instance.currency == "USD"
-    assert instance.money_gross.amount == 30
-    assert instance.money_gross.currency == "USD"
-
-
-def test_taxed_money_currency_init_model_field():
-    instance = CurrencyModel(money_net=Money(10, "USD"))
-    assert instance.money_net_amount == 10
-    assert instance.currency == "USD"

--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -52,7 +52,7 @@ def price_with_decimals():
 
 def test_money_field_init():
     field = MoneyField(amount_field="amount", currency_field="currency")
-    assert field.get_default() == Money(0, "")
+    assert field.get_default() == Money(0, None)
     assert field.amount_field == "amount"
     assert field.currency_field == "currency"
 
@@ -61,7 +61,7 @@ def test_money_field_formfield():
     field = MoneyField(amount_field="amount", currency_field="currency")
     form_field = field.formfield()
     assert isinstance(form_field, forms.MoneyField)
-    assert isinstance(form_field.widget, widgets.MoneyConstCurrencyInput)
+    assert isinstance(form_field.widget, widgets.FixedCurrencyMoneyInput)
 
 
 def test_money_field_formfield_select():
@@ -193,8 +193,8 @@ def test_render_money_input():
     assert "USD" in result
 
 
-def test_render_money_const_currency_input():
-    widget = widgets.MoneyConstCurrencyInput(currency="BTC", attrs={"key": "value"})
+def test_render_fixed_currency_money_input():
+    widget = widgets.FixedCurrencyMoneyInput(currency="BTC", attrs={"key": "value"})
     result = widget.render("price", Money(5, "BTC"), attrs={"foo": "bar"})
     attrs = ['foo="bar"', 'key="value"', 'value="5"', "price_0", "BTC"]
     for attr in attrs:

--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -100,14 +100,27 @@ def test_money_field_set_instance_values():
 
 
 def test_taxed_money_field_init():
-    field = TaxedMoneyField(net_field="price_net", gross_field="price_gross")
-    assert field.net_field == "price_net"
-    assert field.gross_field == "price_gross"
+    field = TaxedMoneyField(
+        net_amount_field="price_net",
+        gross_amount_field="price_gross",
+        currency="currency",
+    )
+    assert field.net_amount_field == "price_net"
+    assert field.gross_amount_field == "price_gross"
+    assert field.currency == "currency"
 
 
 def test_compare_taxed_money_field_with_same_type_field():
-    field_1 = TaxedMoneyField(net_field="price_net", gross_field="price_gross")
-    field_2 = TaxedMoneyField(net_field="price_net", gross_field="price_gross")
+    field_1 = TaxedMoneyField(
+        net_amount_field="price_net",
+        gross_amount_field="price_gross",
+        currency="currency",
+    )
+    field_2 = TaxedMoneyField(
+        net_amount_field="price_net",
+        gross_amount_field="price_gross",
+        currency="currency",
+    )
 
     # Comparision is based on creation_counter attribute
     assert field_1 < field_2
@@ -116,7 +129,11 @@ def test_compare_taxed_money_field_with_same_type_field():
 
 
 def test_compare_taxed_money_field_with_django_field():
-    field_1 = TaxedMoneyField(net_field="price_net", gross_field="price_gross")
+    field_1 = TaxedMoneyField(
+        net_amount_field="price_net",
+        gross_amount_field="price_gross",
+        currency="currency",
+    )
     field_2 = DecimalField(default="5", max_digits=9, decimal_places=2)
 
     # Comparision is based on creation_counter attribute
@@ -126,7 +143,11 @@ def test_compare_taxed_money_field_with_django_field():
 
 
 def test_compare_taxed_money_field_with_money_field():
-    field_1 = TaxedMoneyField(net_field="price_net", gross_field="price_gross")
+    field_1 = TaxedMoneyField(
+        net_amount_field="price_net",
+        gross_amount_field="price_gross",
+        currency="currency",
+    )
     field_2 = MoneyField(amount_field="money_net_amount", currency_field="currency")
 
     # Comparision is based on creation_counter attribute

--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -136,6 +136,17 @@ def test_compare_taxed_money_field_with_django_field():
     assert field_1 == field_2
 
 
+def test_compare_taxed_money_field_with_money_currency_field():
+    field_1 = TaxedMoneyField(net_field="price_net", gross_field="price_gross")
+    field_2 = MoneyCurrencyField(
+        amount_field="money_net_amount", currency_field="currency"
+    )
+    # Comparision is based on creation_counter attribute
+    assert field_1 < field_2
+    field_2.creation_counter -= 1
+    assert field_1 == field_2
+
+
 @pytest.mark.parametrize(
     "data,initial,expected_result",
     [
@@ -399,6 +410,18 @@ def test_compare_money_currency_field_with_django_field():
         amount_field="money_net_amount", currency_field="currency"
     )
     field_2 = MoneyField(currency="BTC", default="5", max_digits=9, decimal_places=2)
+
+    # Comparision is based on creation_counter attribute
+    assert field_1 < field_2
+    field_2.creation_counter -= 1
+    assert field_1 == field_2
+
+
+def test_compare_money_currency_field_with_taxed_money_field():
+    field_1 = MoneyCurrencyField(
+        amount_field="money_net_amount", currency_field="currency"
+    )
+    field_2 = TaxedMoneyField(net_field="price_net", gross_field="price_gross")
 
     # Comparision is based on creation_counter attribute
     assert field_1 < field_2


### PR DESCRIPTION
Existing `MoneyField` has a major limitation - can store only one currency in the one table column. For most of the usages it is enough, but if user wants to store prices in many currencies, it leads to the problem.
This PR adds new field, `MoneyCurrencyField`, which solves it. It stores amount of cash and currency in two table column. Existing users who don't need this feature could still use `MoneyField`.