### PR TITLE
Fix getting zero money in MoneyField

### DIFF
--- a/django_prices/models.py
+++ b/django_prices/models.py
@@ -86,7 +86,7 @@ class MoneyField(NonDatabaseFieldBase):
 
         amount = getattr(instance, self.amount_field)
         currency = getattr(instance, self.currency_field)
-        if amount and currency:
+        if amount is not None and currency is not None:
             return Money(amount, currency)
         return self.get_default()
 

--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -476,3 +476,8 @@ def test_get_default_values_wth_nulls():
     assert object_with_defaults.price_net is None
     assert object_with_defaults.price_net is None
     assert object_with_defaults.price is None
+
+
+def test_get_money_field_zero_amount():
+    instance = Model(price_net_amount=Decimal("0"), currency="USD")
+    assert instance.price_net == Money(amount=Decimal("0"), currency="USD")


### PR DESCRIPTION
I've found trivial bug in the code with serious consequences: trying to get money with zero amount from database returns default value instead of zero money.