### PR TITLE
Fixes #71 & non-use of TaxedMoneyField.verbose_name

### DIFF
--- a/django_prices/models.py
+++ b/django_prices/models.py
@@ -143,6 +143,7 @@ class TaxedMoneyField(NonDatabaseFieldBase):
         self.net_amount_field = net_amount_field
         self.gross_amount_field = gross_amount_field
         self.currency = currency
+        self.verbose_name = verbose_name
 
     def __str__(self):
         return (

--- a/django_prices/models.py
+++ b/django_prices/models.py
@@ -19,6 +19,7 @@ class NonDatabaseFieldBase:
     blank = True
     concrete = False
     editable = False
+    unique = False
 
     is_relation = False
     remote_field = None

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author_email="hello@mirumee.com",
     description="Django fields for the prices module",
     license="BSD",
-    version="2.1.0",
+    version="2.1.1",
     url="https://github.com/mirumee/django-prices",
     packages=["django_prices", "django_prices.templatetags", "django_prices.utils"],
     include_package_data=True,


### PR DESCRIPTION
Adds the `unique` attribute to `NonDatabaseFieldBase` & fixes non-use of `verbose_name` kwarg in `TaxedMoneyField`.

Doing this on behalf of @Zagrebelin since I didn't see any existing PR for the same.