### PR TITLE
Support Django 3 and Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 python:
   - "3.6"
   - "3.7"
+  - "3.8"
 cache:
   pip: true
 install:
@@ -13,16 +14,16 @@ script:
   - tox
 env:
   matrix:
-    - DJANGO="1.11"
-    - DJANGO="2.0"
-    - DJANGO="2.1"
+    - DJANGO="2.2"
+    - DJANGO="3.0"
     - DJANGO="master"
 matrix:
   allow_failures:
     - python: "3.6"
       env: DJANGO="master"
-  exclude:
     - python: "3.7"
-      env: DJANGO="1.11"
+      env: DJANGO="master"
+    - python: "3.8"
+      env: DJANGO="master"
 after_success:
   - codecov

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ django-prices: Django fields for the `prices` module
 
 * `pip install django-prices`
 * Add `django_prices` to your `INSTALLED_APPS` at `settings.py`
-* Follow `django-babel` [instructions](https://github.com/python-babel/django-babel/#using-the-middleware) and update both your `INSTALLED_APPS` and `MIDDLEWARE_CLASSES`.
+* Follow `enmerkar` [instructions](https://github.com/Zegocover/enmerkar#using-the-middleware) and update both your `INSTALLED_APPS` and `MIDDLEWARE_CLASSES`.
 
 # Features
 

--- a/django_prices/templatetags/prices.py
+++ b/django_prices/templatetags/prices.py
@@ -1,6 +1,6 @@
 from django import template
 
-from django_babel.templatetags.babel import currencyfmt
+from enmerkar.templatetags.babel import currencyfmt
 
 from ..utils.formatting import format_price
 

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,12 @@ CLASSIFIERS = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-
 
 setup(
     name="django-prices",
@@ -22,12 +22,17 @@ setup(
     author_email="hello@mirumee.com",
     description="Django fields for the prices module",
     license="BSD",
-    version="2.1.0",
+    version="2.2.0",
     url="https://github.com/mirumee/django-prices",
     packages=["django_prices", "django_prices.templatetags", "django_prices.utils"],
     include_package_data=True,
     classifiers=CLASSIFIERS,
-    install_requires=["Babel>=2.2", "Django>=1.11,<3", "django-babel", "prices>=1.0.0"],
+    install_requires=[
+        "Babel>=2.2",
+        "Django>=2.2,<4",
+        "enmerkar>=0.7.1",
+        "prices>=1.0.0",
+    ],
     platforms=["any"],
     zip_safe=False,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,14 @@
 [tox]
 envlist =
-    py{34,35,36}-django111
-    py{34,35,36,37}-django20
-    py{35,36,37}-django21
-    py{35,36}-django_master
+    py{36,37,38}-django22
+    py{36,37,38}-django30
+    py{36,37,38}-django_master
 
 [testenv]
 pip_pre = true
 deps =
-    django111: django>=1.11a1,<1.12
-    django20: django>=2.0,<2.1
-    django21: django>=2.1,<2.2
+    django22: django>=2.2,<2.3
+    django30: django>=3.0,<3.1
     pytest
     pytest-cov
     pytest-django
@@ -22,17 +20,15 @@ setenv =
 
 [travis]
 python =
-    3.4: py34
-    3.5: py35
     3.6: py36
     3.7: py37
+    3.8: py38
 unignore_outcomes = True
 
 [travis:env]
 DJANGO =
-    1.11: django111
-    2.0: django20
-    2.1: django21
+    2.2: django22
+    3.9: django30
     master: django_master
 
 [pytest]


### PR DESCRIPTION
* Drop support for Python 3.4
* Add support for Python 3.8
* Drop support for Django <2.2
* Add support for Django 3.0
* Replace `django-babel` (dead) with `enmerkar` (currently supported fork)