### PR TITLE
python support remove <3.10

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v3

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ dist: xenial
 language: python
 sudo: false
 python:
-  - "3.8"
-  - "3.9"
   - "3.10"
   - "3.11"
   - "3.12"
@@ -23,16 +21,6 @@ env:
     - DJANGO="master"
 matrix:
   allow_failures:
-    - python: "3.8"
-      env: DJANGO="5.0"
-    - python: "3.8"
-      env: DJANGO="master"
-
-    - python: "3.9"
-      env: DJANGO="5.0"
-    - python: "3.9"
-      env: DJANGO="master"
-
     - python: "3.10"
       env: DJANGO="3.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target_version = ['py38', 'py39', 'py310', 'py311', 'py312', 'py313']
+target_version = ['py310', 'py311', 'py312', 'py313']
 include = '\.pyi?$'
 exclude = '''
 /(\.git/

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,6 @@ CLASSIFIERS = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -35,6 +33,7 @@ setup(
     packages=["django_prices", "django_prices.templatetags", "django_prices.utils"],
     include_package_data=True,
     classifiers=CLASSIFIERS,
+    python_requires=">=3.10",
     install_requires=[
         "Babel>=2.2",
         "Django>=3.0,<6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
     ; https://docs.djangoproject.com/en/dev/releases/3.0/
-    py{38,39}-django3
+    py310-django3
     ; https://docs.djangoproject.com/en/dev/releases/4.0/
-    py{38,39,310}-django4
+    py310-django4
     ; https://docs.djangoproject.com/en/dev/releases/5.0/
     py{310,311,312,313}-django5
     ; https://docs.djangoproject.com/en/dev/releases/6.0/
@@ -11,8 +11,6 @@ envlist =
 
 [gh-actions]
 python =
-     3.8: py38
-     3.9: py39
      3.10: py310
      3.11: py311
      3.12: py312
@@ -35,8 +33,6 @@ setenv =
 
 [travis]
 python =
-    3.8: py38
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312


### PR DESCRIPTION
This change removes support for Python versions below 3.10, making it compatible with [Django 5.2.x requirements](https://docs.djangoproject.com/en/5.2/releases/5.0/#python-compatibility).