### PR TITLE
Fix FixedCurrencyMoneyInput.decompress to always return currency

### DIFF
--- a/django_prices/widgets.py
+++ b/django_prices/widgets.py
@@ -33,7 +33,7 @@ class FixedCurrencyMoneyInput(forms.MultiWidget):
     def decompress(self, value):
         if value and isinstance(value, Money):
             return [value.amount, self.currency]
-        return [None, None]
+        return [None, self.currency]
 
     def render(self, name, value, attrs=None, renderer=None):
         widget = super().render(name, value, attrs=attrs, renderer=renderer)

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -34,6 +34,20 @@ def test_render_fixed_currency_money_input():
         assert attr in result
 
 
+def test_fixed_currency_money_input_decompress_with_none():
+    """Test that decompress returns currency even when value is None."""
+    widget = widgets.FixedCurrencyMoneyInput(currency="USD")
+    result = widget.decompress(None)
+    assert result == [None, "USD"], "Currency should be set even when value is None"
+
+
+def test_fixed_currency_money_input_decompress_with_value():
+    """Test that decompress returns correct values when Money object is provided."""
+    widget = widgets.FixedCurrencyMoneyInput(currency="USD")
+    result = widget.decompress(Money(10, "USD"))
+    assert result == [10, "USD"], "Should return amount and currency from Money object"
+
+
 @pytest.mark.parametrize(
     "data,initial,expected_result",
     [


### PR DESCRIPTION
# Fix: Return currency in FixedCurrencyMoneyInput.decompress() when value is None

## Problem
`FixedCurrencyMoneyInput.decompress()` returns `[None, None]` when value is `None`, causing the hidden currency input to have no value. This leads to form validation errors and data corruption.

## Solution
Changed to return `[None, self.currency]` to ensure the currency is always available.

## Impact
- Fixes form submission failures with empty price fields
- Prevents database corruption from empty currency codes
- Backwards compatible - only affects empty/None values